### PR TITLE
Removing `fact` that is not used

### DIFF
--- a/roles/router/tasks/install.yml
+++ b/roles/router/tasks/install.yml
@@ -1,8 +1,5 @@
 ---
 
-- set_fact:
-    systemd_network_dir: /etc/systemd/network
-
 - name: set net.ipv4.conf.all.arp_filter to 1
   ansible.posix.sysctl:
     name: net.ipv4.conf.all.arp_filter

--- a/roles/router/tasks/uninstall.yml
+++ b/roles/router/tasks/uninstall.yml
@@ -1,8 +1,5 @@
 ---
 
-- set_fact:
-    systemd_network_dir: /etc/systemd/network
-
 - name: "remove a static route on oai host for {{ core.upf.access_subnet }} via {{ core.amf.ip }}"
   shell: |
     ip route del {{ core.upf.access_subnet }} via {{ core.amf.ip }}


### PR DESCRIPTION
Remove `set_fact` that I do not see being used anywhere in the install or uninstall tasks