### PR TITLE
Add multihop support to deploy GNB's from multiple hops

### DIFF
--- a/roles/router/defaults/main.yml
+++ b/roles/router/defaults/main.yml
@@ -10,5 +10,6 @@ oai:
 core:
   upf:
     access_subnet: "192.168.252.1/24"
+    multihop_gnb: false
   amf:
     ip: "172.16.248.6"

--- a/roles/router/tasks/install.yml
+++ b/roles/router/tasks/install.yml
@@ -88,7 +88,7 @@
 - name: configure static route for upf traffic on oai node
   shell: |
     ip route add {{ core.upf.access_subnet | regex_replace('[0-9]+/24', '0/24') }} via {{ core.amf.ip }}
-  when: (inventory_hostname in groups['oai_nodes'][0]) and (inventory_hostname not in groups['master_nodes'])
+  when: (inventory_hostname in groups['oai_nodes'][0]) and (inventory_hostname not in groups['master_nodes']) and core.upf.multihop_gnb == false
   become: true
   ignore_errors: yes
 

--- a/roles/router/tasks/uninstall.yml
+++ b/roles/router/tasks/uninstall.yml
@@ -3,7 +3,7 @@
 - name: "remove a static route on oai host for {{ core.upf.access_subnet | regex_replace('[0-9]+/24', '0/24') }} via {{ core.amf.ip }}"
   shell: |
     ip route del {{ core.upf.access_subnet | regex_replace('[0-9]+/24', '0/24') }} via {{ core.amf.ip }}
-  when: (inventory_hostname in groups['oai_nodes'][0]) and (inventory_hostname not in groups['master_nodes'])
+  when: (inventory_hostname in groups['oai_nodes'][0]) and (inventory_hostname not in groups['master_nodes']) and core.upf.multihop_gnb == false
   become: true
   ignore_errors: yes
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,5 +19,6 @@ oai:
 core:
   upf:
     access_subnet: "192.168.252.1/24"
+    multihop_gnb: false
   amf:
     ip: "172.16.248.6"


### PR DESCRIPTION
By default onramp deploys UPF using isolated N3/N6 networks (192.168.252.x/192.168.250.x) respectively. But in most customer deployments the GNB's will be deployed on different subnets than the access subnets. In such cases the current deployment will not work. So we have to deploy the access n/w (N3) using the same subnet as host DATA_IFACE.

For example,
DATA_IFACE = 10.21.61.x
upf_access_interface = 10.21.61.y

GNB subnet: 10.202.1.x

In this case, the GNB's deployed on different subnets can directly access UPF N3 interface (10.21.61.y) using the existing networking. But if we use the isolated access network (like 192.168.252.x) then the traffic from GNB's cannot reach UPF.

This solution helps deploy GNB's in same subnet and different subnets. Please note that by default still onramp uses the isolated n/w deployment (current behavior). Our mechanism will be used only if user sets multihop_gnb to true in vars/main.yml.