### PR TITLE
Avoid deleting Docker image to minimize time for next deployment(s)

### DIFF
--- a/roles/gNb/tasks/stop.yml
+++ b/roles/gNb/tasks/stop.yml
@@ -13,11 +13,3 @@
     state: absent
   when: inventory_hostname in groups['oai_nodes']
   become: true
-
-- name: remove {{ oai.docker.container.gnb_image }} image
-  community.docker.docker_image:
-    name: "{{ oai.docker.container.gnb_image }}"
-    state: absent
-    force_absent: true
-  when: inventory_hostname in groups['oai_nodes']
-  become: true

--- a/roles/uEsimulator/tasks/stop.yml
+++ b/roles/uEsimulator/tasks/stop.yml
@@ -13,11 +13,3 @@
     state: absent
   when: inventory_hostname in groups['oai_nodes'][0]
   become: true
-
-- name: remove {{ oai.docker.container.ue_image }} image
-  community.docker.docker_image:
-    name: "{{ oai.docker.container.ue_image }}"
-    state: absent
-    force_absent: true
-  when: inventory_hostname in groups['oai_nodes'][0]
-  become: true


### PR DESCRIPTION
The image we use does not frequently change, so, there is no reason to keep downloading it all the time. Downloading it the first time would suffice